### PR TITLE
Fixed the method to get the total threads

### DIFF
--- a/src/main/java/com/baolu/jmeter/services/FileServer.java
+++ b/src/main/java/com/baolu/jmeter/services/FileServer.java
@@ -613,7 +613,7 @@ public class FileServer {
      */
     public int getBlockSize(JMeterContext context, int fileLines){
         int blockSize = 0;
-        int threadTotal = JMeterContextService.getContext().getThreadGroup().getNumThreads();
+        int threadTotal = JMeterContextService.getTotalThreads();
         if (fileLines > 0) {
             blockSize = fileLines / threadTotal;
             if (blockSize < 1) {


### PR DESCRIPTION
Hello,

The method JMeterContextService.getContext().getThreadGroup().getNumThreads(); will return the total number of active threads in the thread group - which is kind of misleading 

Refer:  https://jmeter.apache.org/api/org/apache/jmeter/threads/JMeterContextService.html#getNumberOfThreads--
If we have 2 threads and rampup of 1800 - The method will return the total active thread as 1 (which is  a wrong calc)


Where as - if we use JMeterContextService.getTotalThreads(); - this will return the total threads allocated for the thread group.
Refer: https://jmeter.apache.org/api/org/apache/jmeter/threads/JMeterContextService.html#getTotalThreads--